### PR TITLE
Fix CloudFront function headers

### DIFF
--- a/function.js
+++ b/function.js
@@ -6,8 +6,8 @@ function handler(event) {
 
   response.statusCode = 200;
   response.statusDescription = 'OK';
-  response.headers['content-type'] = [{ key: 'Content-Type', value: 'text/plain' }];
-  response.headers['x-amz-date'] = [{ key: 'X-Amz-Date', value: timestamp }];
+  response.headers['content-type'] = { value: 'text/plain' };
+  response.headers['x-amz-date'] = { value: timestamp };
   response.body = {
     encoding: 'text',
     data: timestamp,

--- a/lib/x-amz-date-stack.ts
+++ b/lib/x-amz-date-stack.ts
@@ -22,6 +22,7 @@ export class XAmzDateStack extends cdk.Stack {
     const cfFunction = new cloudfront.Function(this, 'CloudFrontFunction', {
       functionName: 'xAmzDateFunction',
       comment: 'Return current X-Amz-Date string',
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
       code: cloudfront.FunctionCode.fromFile({ filePath: 'function.js' }),
     });
 


### PR DESCRIPTION
## Summary
- correct header format for CloudFront Functions
- set runtime to js2

## Testing
- `./run.sh test`
- `./integration-test.sh` *(fails: HTTP request failed with status 7)*