### PR TITLE
Add S3-hosted preview image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # x-amz-date
 
 Demonstration CloudFront function returning the current timestamp.
+The HTML page and preview image are served from an S3 bucket.
 
 ## Usage
 
@@ -18,4 +19,12 @@ npx cdk deploy --require-approval never
 ```
 
 The deployment automatically packages `function.js` and provisions the
-CloudFront distribution.
+CloudFront distribution and S3 bucket.
+
+Upload a `preview.png` file to the bucket with:
+
+```
+scripts/upload-preview.sh /path/to/preview.png
+```
+
+The image will be available at `https://x-amz.date/preview.png`.

--- a/function.js
+++ b/function.js
@@ -1,4 +1,6 @@
 function handler(event) {
+  var response = event.response;
+
   var now = new Date();
 
   // Precompute each part manually to avoid closure + method calls
@@ -14,16 +16,13 @@ function handler(event) {
 
   var timestamp = `${year}${pad2(month)}${pad2(day)}T${pad2(hour)}${pad2(minute)}${pad2(second)}Z`;
 
-  var response = event.response;
   response.statusCode = 200;
   response.statusDescription = 'OK';
-  response.headers['content-type'] = { value: 'text/plain' };
-  response.headers['content-encoding'] = { value: 'identity' };
   response.headers['x-amz-date'] = { value: timestamp };
-  response.body = {
-    encoding: 'text',
-    data: timestamp,
-  };
+
+  if (response.body && response.body.encoding === 'text') {
+    response.body.data = response.body.data.replace('###TIMESTAMP###', timestamp);
+  }
 
   return response;
 }

--- a/run.sh
+++ b/run.sh
@@ -3,21 +3,15 @@ set -e
 
 js=$(<function.js)
 
-dummy_response='{
-  statusCode: "200",
-  statusDescription: "OK",
-  headers: {},
-  body: {
-    encoding: "text",
-    data: ""
-  }
+# Minimal request object for local execution
+dummy_request='{
+  uri: "/"
 }'
 
 if [ "$1" == "-r" ]; then
-  node -e "$js; const event = { response: $dummy_response }; const res = handler(event); console.dir(res, { depth: null });"
+  node -e "$js; const fs=require('fs'); const html=fs.readFileSync('site/index.html','utf8'); const event={ request: $dummy_request, response: { statusCode:'200', statusDescription:'OK', headers:{'content-type':{value:'text/html; charset=utf-8'}}, body:{encoding:'text', data: html}}}; const res=handler(event); console.dir(res,{depth:null});"
 elif [ "$1" == "test" ]; then
-  node -e "$js; const event = { response: $dummy_response }; const res = handler(event); require('./test.js').testXAmzDate(res.body.data);"
+  node -e "$js; const fs=require('fs'); const html=fs.readFileSync('site/index.html','utf8'); const event={ request: $dummy_request, response: { statusCode:'200', statusDescription:'OK', headers:{'content-type':{value:'text/html; charset=utf-8'}}, body:{encoding:'text', data: html}}}; const res=handler(event); require('./test.js').testXAmzDate(res.headers['x-amz-date'].value);"
 else
-  node -e "$js; const event = { response: $dummy_response }; console.log(handler(event).body.data);"
+  node -e "$js; const fs=require('fs'); const html=fs.readFileSync('site/index.html','utf8'); const event={ request: $dummy_request, response: { statusCode:'200', statusDescription:'OK', headers:{'content-type':{value:'text/html; charset=utf-8'}}, body:{encoding:'text', data: html}}}; console.log(handler(event).body.data);"
 fi
-

--- a/scripts/upload-preview.sh
+++ b/scripts/upload-preview.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 /path/to/preview.png" >&2
+  exit 1
+fi
+
+aws s3 cp "$1" s3://x-amz-date-site/preview.png --acl public-read

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>x-amz-date</title>
+  <meta property="og:title" content="x-amz-date" />
+  <meta property="og:image" content="/preview.png" />
+  <meta property="og:description" content="Current x-amz-date timestamp" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="/preview.png" />
+</head>
+<body>
+  <pre>###TIMESTAMP###</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve HTML from an S3 bucket and inject the timestamp via the CloudFront function
- host `preview.png` in the bucket and provide an upload helper
- update local run script to load the HTML file
- document the preview image location

## Testing
- `./run.sh test`
- `./integration-test.sh` *(fails: HTTP request failed)*