### PR TITLE
Negotiate timestamp responses by Accept header

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,13 @@ jobs:
       AWS_REGION: ${{ vars.AWS_REGION }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-      - run: npm install
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/GitHubFederationRole

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules/
 dist/
 .cdk.staging/
 cdk.out/
-package-lock.json
 .DS_STORE

--- a/README.md
+++ b/README.md
@@ -3,10 +3,16 @@
 Demonstration CloudFront function returning the current timestamp.
 The HTML page and preview image are served from an S3 bucket.
 
+Requests without an `Accept` header (and non-HTML requests) receive the timestamp
+as a single `text/plain` string. Requests that explicitly accept `text/html`
+receive the rich-link HTML page. Preview image and favicon requests pass through
+to the S3 origin.
+
 ## Usage
 
 - `./run.sh` – run the function locally and print the timestamp.
-- `./run.sh test` – run a local test of the function output.
+- `npm test` or `./run.sh test` – run the local behavior tests.
+- `npm run build` – type-check the CDK application.
 - `./integration-test.sh` – hit the deployed URL and verify the response.
 
 ## Deployment

--- a/function.js
+++ b/function.js
@@ -1,32 +1,38 @@
 function handler(event) {
+  var request = event.request;
   var response = event.response;
-  
-  if (request.uri.endsWith('.png')) {
+
+  // Static browser assets must retain the body and content type from S3.
+  if (request.uri.endsWith('.png') || request.uri === '/favicon.ico') {
     return response;
   }
 
   var now = new Date();
-
-  // Precompute each part manually to avoid closure + method calls
   var year = now.getUTCFullYear();
   var month = now.getUTCMonth() + 1;
   var day = now.getUTCDate();
   var hour = now.getUTCHours();
   var minute = now.getUTCMinutes();
   var second = now.getUTCSeconds();
-
-  // Inline padding with arithmetic to avoid string method overhead
   var pad2 = (n) => (n < 10 ? '0' + n : '' + n);
-
   var timestamp = `${year}${pad2(month)}${pad2(day)}T${pad2(hour)}${pad2(minute)}${pad2(second)}Z`;
+  var accept = request.headers.accept ? request.headers.accept.value : '';
+  var acceptsHtml = accept.split(',').some((entry) => {
+    var parts = entry.trim().toLowerCase().split(';');
+    var quality = parts.find((part) => part.trim().startsWith('q='));
+    return parts[0].trim() === 'text/html' && (!quality || parseFloat(quality.split('=')[1]) > 0);
+  });
 
   response.statusCode = 200;
   response.statusDescription = 'OK';
   response.headers['x-amz-date'] = { value: timestamp };
-  response.headers['content-type'] = { value: 'text/html' };
   response.headers['cache-control'] = { value: 'no-store' };
-  response.body = `
-<!DOCTYPE html>
+
+  if (acceptsHtml) {
+    response.headers['content-type'] = { value: 'text/html; charset=utf-8' };
+    response.body = {
+      encoding: 'text',
+      data: `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -41,8 +47,12 @@ function handler(event) {
 <body>
   <code>${timestamp}</code>
 </body>
-</html>
-  `;
+</html>`,
+    };
+  } else {
+    response.headers['content-type'] = { value: 'text/plain; charset=utf-8' };
+    response.body = { encoding: 'text', data: timestamp };
+  }
 
   return response;
 }

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -7,5 +7,7 @@ if [ -n "$STATUS" ]; then
   exit $STATUS
 fi
 echo "Output: $OUTPUT"
-node -e "require('./test.js').testXAmzDate('$OUTPUT')"
-
+if [[ ! "$OUTPUT" =~ ^[0-9]{8}T[0-9]{6}Z$ ]]; then
+  echo "Response is not a single x-amz-date timestamp" >&2
+  exit 1
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,529 @@
+{
+  "name": "x-amz-date",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "x-amz-date",
+      "license": "MIT",
+      "dependencies": {
+        "aws-cdk-lib": "^2.262.2",
+        "constructs": "^10.7.2",
+        "source-map-support": "^0.5.21"
+      },
+      "devDependencies": {
+        "@types/node": "^18.18.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "54.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.14.0.tgz",
+      "integrity": "sha512-JCZCzgp3SuXQVljaKqXnttHzcezEHt9Ag/YipK0XwUFD+Iz2T4jY7gUc3pA25Uq6pzY2n9DvO/nEU++dPXW4Rw==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.5",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.262.2",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.2.tgz",
+      "integrity": "sha512-lWQRW/AHxB4gMgkRmfYQIKWqiJLD4whkl7sQF3c26eK1DVt1Jw9rNBSFvVQ+DZddxxnifNGan/i97YgsNpgOeQ==",
+      "bundleDependencies": [
+        "@aws/cloudformation-validate",
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.5.1-beta",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.6",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.5",
+        "punycode": "^2.3.1",
+        "semver": "^7.8.5",
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.6",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.5.1-beta",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.8.5",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/constructs": {
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.7.2.tgz",
+      "integrity": "sha512-vA7JOqvO/xwq2HBCuq3qc6V2R9mHZCxJ8HPoucUcUWJY88YULe7bzMcsdBy27/gJJIphZi73U1oIXDY2Eqg6nA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,14 +2,18 @@
   "name": "x-amz-date",
   "private": true,
   "license": "MIT",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "node --test test.js"
+  },
   "dependencies": {
-    "aws-cdk-lib": "^2.199.0",
-    "constructs": "^10.2.0",
+    "aws-cdk-lib": "^2.262.2",
+    "constructs": "^10.7.2",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@types/node": "^18.18.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.2.0"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -5,13 +5,14 @@ js=$(<function.js)
 
 # Minimal request object for local execution
 dummy_request='{
-  uri: "/"
+  uri: "/",
+  headers: {}
 }'
 
 if [ "$1" == "-r" ]; then
   node -e "$js; const fs=require('fs'); const html=fs.readFileSync('site/index.html','utf8'); const event={ request: $dummy_request, response: { statusCode:'200', statusDescription:'OK', headers:{'content-type':{value:'text/html; charset=utf-8'}}, body:{encoding:'text', data: html}}}; const res=handler(event); console.dir(res,{depth:null});"
 elif [ "$1" == "test" ]; then
-  node -e "$js; const fs=require('fs'); const html=fs.readFileSync('site/index.html','utf8'); const event={ request: $dummy_request, response: { statusCode:'200', statusDescription:'OK', headers:{'content-type':{value:'text/html; charset=utf-8'}}, body:{encoding:'text', data: html}}}; const res=handler(event); require('./test.js').testXAmzDate(res.headers['x-amz-date'].value);"
+  node --test test.js
 else
   node -e "$js; const fs=require('fs'); const html=fs.readFileSync('site/index.html','utf8'); const event={ request: $dummy_request, response: { statusCode:'200', statusDescription:'OK', headers:{'content-type':{value:'text/html; charset=utf-8'}}, body:{encoding:'text', data: html}}}; console.log(handler(event).body.data);"
 fi

--- a/test.js
+++ b/test.js
@@ -1,21 +1,56 @@
-function testXAmzDate(output) {
-  const received = new Date(
-    output.slice(0, 4) + '-' +
-    output.slice(4, 6) + '-' +
-    output.slice(6, 8) + 'T' +
-    output.slice(9, 11) + ':' +
-    output.slice(11, 13) + ':' +
-    output.slice(13, 15) + 'Z'
-  );
-  const now = new Date();
-  const diff = Math.abs(now - received);
-  console.log("Diff (ms):", diff);
-  if (diff < 1000) {
-    console.log("✅ Timestamp is within 1 second");
-  } else {
-    console.error("❌ Timestamp is out of sync");
-    process.exit(1);
-  }
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const context = vm.createContext({ Date });
+vm.runInContext(fs.readFileSync('function.js', 'utf8'), context);
+
+function invoke({ uri = '/', accept } = {}) {
+  const headers = {};
+  if (accept !== undefined) headers.accept = { value: accept };
+
+  return context.handler({
+    request: { uri, headers },
+    response: {
+      statusCode: '200',
+      headers: { 'content-type': { value: 'text/html' } },
+      body: { encoding: 'text', data: 'origin body' },
+    },
+  });
 }
 
-module.exports = { testXAmzDate };
+function assertTimestamp(value) {
+  assert.match(value, /^\d{8}T\d{6}Z$/);
+  const parsed = new Date(value.replace(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/, '$1-$2-$3T$4:$5:$6Z'));
+  assert.ok(Math.abs(Date.now() - parsed.getTime()) < 2_000);
+}
+
+test('a request without Accept receives one plain timestamp string', () => {
+  const response = invoke();
+  assert.equal(response.headers['content-type'].value, 'text/plain; charset=utf-8');
+  assertTimestamp(response.body.data);
+  assert.equal(response.body.data, response.headers['x-amz-date'].value);
+});
+
+test('only an explicit HTML request receives the rich-link page', () => {
+  const response = invoke({ accept: 'text/html,application/xhtml+xml;q=0.9' });
+  assert.equal(response.headers['content-type'].value, 'text/html; charset=utf-8');
+  assert.match(response.body.data, /^<!DOCTYPE html>/);
+  assert.match(response.body.data, /property="og:image"/);
+  assert.match(response.body.data, new RegExp(response.headers['x-amz-date'].value));
+});
+
+test('wildcard and disabled HTML accept types receive plain text', () => {
+  assert.equal(invoke({ accept: '*/*' }).headers['content-type'].value, 'text/plain; charset=utf-8');
+  assert.equal(invoke({ accept: 'text/html;q=0, */*' }).headers['content-type'].value, 'text/plain; charset=utf-8');
+});
+
+test('image and favicon responses pass through unchanged', () => {
+  for (const uri of ['/preview.png', '/favicon.ico']) {
+    const response = invoke({ uri, accept: 'image/*' });
+    assert.equal(response.body.data, 'origin body');
+    assert.equal(response.headers['content-type'].value, 'text/html');
+    assert.equal(response.headers['x-amz-date'], undefined);
+  }
+});


### PR DESCRIPTION
### Motivation

- Make the CloudFront function return a single plain-text timestamp for non-HTML requests or requests missing an `Accept` header, while still serving the rich-link HTML page for explicit `text/html` requests.
- Ensure static assets (preview image and favicon) are passed through from S3 unchanged.
- Bring project dependencies and CI up to date for more reproducible local/CI runs.

### Description

- Add `Accept`-header negotiation to `function.js` so that requests that explicitly accept `text/html` receive the full HTML page and other requests (including those missing `Accept`) receive a single `text/plain` timestamp string, with `x-amz-date` and `cache-control` headers set.
- Preserve passthrough behavior for `.png` and `/favicon.ico` requests to avoid modifying S3-served assets.
- Replace ad-hoc body replacement with explicit `response.body` objects for both HTML (`encoding: 'text', data: '<!DOCTYPE html>...'`) and plain-text responses (`encoding: 'text', data: timestamp`).
- Add a new test suite `test.js` that loads `function.js` into a VM and verifies behavior for missing/wildcard/disabled HTML Accept headers, explicit HTML requests, and image/favicon passthrough.
- Add `package-lock.json`, bump dependency ranges for `aws-cdk-lib`, `constructs`, `typescript`, and `ts-node`, add `test` and `build` npm scripts, and update `.github/workflows/main.yml` to use `actions/setup-node@v4` with Node 22 and to run `npm ci`, `npm test`, and `npm run build` before deployment.
- Update `run.sh` and `integration-test.sh` to exercise the new behavior and test harness.

### Testing

- `npm ci --offline` — succeeded.
- `npm test` — all tests passed (4/4) using `node --test test.js`.
- `npm run build` (`tsc --noEmit`) — succeeded in the final test runs.
- `./run.sh` — prints a single timestamp as expected.
- `./run.sh test` — runs the local VM tests and passed.
- `git diff --check` — no whitespace or trivial diff issues found.
- Note: `npx cdk synth` / CDK CLI steps could not be executed in one environment attempt because `npx` attempted to download the CDK CLI and the registry returned HTTP 403; this is an environment/network restriction and not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ae833ab3883309829c4defdcaeb6b)